### PR TITLE
FIX | Vue | HTML Closing Bracket Spacing

### DIFF
--- a/rules/vue.js
+++ b/rules/vue.js
@@ -314,9 +314,9 @@ module.exports = {
     Warn about spacing of HTML closing brackets
      */
     'vue/html-closing-bracket-spacing': ['warn', {
-      'startTag': 'always',
-      'endTag': 'always',
-      'selfClosingTag': 'always',
+      'startTag': 'never',
+      'endTag': 'never',
+      'selfClosingTag': 'never',
     }],
 
     /*


### PR DESCRIPTION
Fixed spacing issue where extra space was being added to the end of HTML elements